### PR TITLE
Minor fixes/additions from dry run

### DIFF
--- a/docs/part2/02_fastqc.md
+++ b/docs/part2/02_fastqc.md
@@ -211,6 +211,7 @@ process FASTQC {
 
   script:
   """
+  mkdir -p "fastqc_${sample_id}_logs"
   fastqc --outdir "fastqc_${sample_id}_logs" --format fastq $reads_1 $reads_2
   """
 }

--- a/docs/part2/05_scale.md
+++ b/docs/part2/05_scale.md
@@ -216,6 +216,8 @@ Removed /home/user/hello-nextflow/work/c3/feb819a918abd91819c8143053f091
 
     See the [Nextflow docs](https://www.nextflow.io/docs/latest/reference/cli.html#clean) for more information.
 
+    The [Nextflow CLI reference page](https://www.nextflow.io/docs/latest/reference/cli.html) also has useful information on all the other Nextflow subcommands, such as [`nextflow log`](https://www.nextflow.io/docs/latest/reference/cli.html#log) for accessing run metadata.
+
 ## 2.5.4 An introduction to configuration  
 
 In this section, we will explore how Nextflow workflows can be configured


### PR DESCRIPTION
- Fixed the missing mkdir command in part 2.2 - FASTQC process
- Added a link to the CLI reference after the `nextflow clean` section, mentioned `nextflow log` as another useful subcommand.